### PR TITLE
Deduping similar matte frames

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from tqdm import tqdm
 from sammie.smooth import run_smoothing_model, prepare_smoothing_model
 from matanyone.inference.inference_core import InferenceCore
 from matanyone.utils.get_default_model import get_matanyone_model
+from utils.duplicate_frame_handler import replace_similar_matte_frames
 
 # .........................................................................................
 # Global variables
@@ -582,10 +583,14 @@ def draw_points(image, frame_number):
     return image
 
 def lock_ui():
-    return [gr.Button(value="Track Objects", visible=False), gr.Button(value="Cancel", visible=True), gr.Button(value="Undo Last Point", interactive=False), gr.Button(value="Clear Object (frame)", interactive=False), gr.Button(value="Clear Object", interactive=False), gr.Button(value="Clear Tracking Data", interactive=False), gr.Button(value="Clear All", interactive=False), gr.File(label="Upload Video or Image File", file_types=['video', '.mkv', 'image'], interactive=False), gr.Tab(label="Matting", visible=False), gr.Tab(label="Export", visible=False)]
+    return [gr.Button(value="Track Objects", visible=False), gr.Button(value="Cancel", visible=True), gr.Button(value="Undo Last Point", interactive=False), gr.Button(value="Clear Object (frame)", interactive=False), gr.Button(value="Clear Object", interactive=False), gr.Button(value="Clear Tracking Data", interactive=False), gr.Button(value="Clear All", interactive=False), gr.Button(value="Dedupe Mattes", interactive=False), gr.File(label="Upload Video or Image File", file_types=['video', '.mkv', 'image'], interactive=False), gr.Tab(label="Matting", visible=False), gr.Tab(label="Export", visible=False)]
+
+def lock_ui_dedupe():
+    return [gr.Button(value="Track Objects", interactive=False), gr.Button(value="Cancel", visible=False), gr.Button(value="Undo Last Point", interactive=False), gr.Button(value="Clear Object (frame)", interactive=False), gr.Button(value="Clear Object", interactive=False), gr.Button(value="Clear Tracking Data", interactive=False), gr.Button(value="Clear All", interactive=False), gr.Button(value="Dedupe Mattes", interactive=False), gr.File(label="Upload Video or Image File", file_types=['video', '.mkv', 'image'], interactive=False), gr.Tab(label="Matting", visible=False), gr.Tab(label="Export", visible=False)]
 
 def unlock_ui():
-    return [gr.Button(value="Track Objects", visible=True), gr.Button(value="Cancel", visible=False), gr.Button(value="Undo Last Point", interactive=True), gr.Button(value="Clear Object (frame)", interactive=True), gr.Button(value="Clear Object", interactive=True), gr.Button(value="Clear Tracking Data", interactive=True), gr.Button(value="Clear All", interactive=True), gr.File(label="Upload Video or Image File", file_types=['video', '.mkv', 'image'], interactive=True), gr.Tab(label="Matting", visible=True), gr.Tab(label="Export", visible=True)]
+    return [gr.Button(value="Track Objects", visible=True, interactive=True), gr.Button(value="Cancel", visible=False), gr.Button(value="Undo Last Point", interactive=True), gr.Button(value="Clear Object (frame)", interactive=True), gr.Button(value="Clear Object", interactive=True), gr.Button(value="Clear Tracking Data", interactive=True), gr.Button(value="Clear All", interactive=True), gr.Button(value="Dedupe Mattes", interactive=True), gr.File(label="Upload Video or Image File", file_types=['video', '.mkv', 'image'], interactive=True), gr.Tab(label="Matting", visible=True), gr.Tab(label="Export", visible=True)]
+
 
 def lock_ui_matting():
     return [gr.Button(value="Run Matting (based on segmentation mask of selected frame)", visible=False), gr.Button(value="Cancel Matting", visible=True), gr.Radio(["Segmentation Mask", "Matting Result"], label="Viewer Output", value="Matting Result", interactive=False), gr.File(label="Upload Video or Image File", file_types=['video', '.mkv', 'image'], interactive=False), gr.Tab(label="Segmentation", visible=False), gr.Tab(label="Export", visible=False)]
@@ -1182,6 +1187,7 @@ with gr.Blocks(title='Sammie-Roto') as demo:
             - Press the \"Track Objects\" button to track the mask across all frames of the video.
             - If you add or remove any points after tracking, the tracking data will be cleared, and you must run tracking again.
             - The sliders at the bottom can be used to make adjustments to the masks.
+            - Optionally press \"Dedupe Mattes\" to handle video masks with duplicate frames. (e.g. anime which has 2/3 still frames every drawing)
             - When you are satisfied with the result, move to the Export tab at the top to render the video.
             """)
         
@@ -1203,6 +1209,7 @@ with gr.Blocks(title='Sammie-Roto') as demo:
                     cancel_propagate_btn = gr.Button(value="Cancel", visible=False)
                     clear_tracking_btn = gr.Button(value="Clear Tracking Data")
                     clear_all_points_btn = gr.Button(value="Clear All")
+                    dedupe_mattes_btn = gr.Button(value="Dedupe Mattes")
         with gr.Row():
             post_holes_slider = gr.Slider(minimum=0, maximum=50, value=set_postprocessing_holes_slider(), step=1, label="Remove Holes")
             post_dots_slider = gr.Slider(minimum=0, maximum=50, value=set_postprocessing_dots_slider(), step=1, label="Remove Dots")
@@ -1276,7 +1283,8 @@ with gr.Blocks(title='Sammie-Roto') as demo:
     clear_all_points_btn.click(clear_all_points, outputs=point_viewer).then(update_image, inputs=frame_slider, outputs=image_viewer)
     clear_points_obj_btn.click(clear_points_obj, inputs=[frame_slider, object_id], outputs=point_viewer).then(update_image, inputs=frame_slider, outputs=image_viewer)
     clear_all_points_obj_btn.click(clear_all_points_obj, inputs=object_id, outputs=point_viewer).then(update_image, inputs=frame_slider, outputs=image_viewer)
-    propagate_btn.click(lock_ui, outputs=[propagate_btn, cancel_propagate_btn, undo_point_btn, clear_points_obj_btn, clear_all_points_obj_btn, clear_tracking_btn, clear_all_points_btn, video_input, matting_tab, export_tab]).then(propagate_masks, outputs=[frame_slider, image_viewer]).then(unlock_ui, outputs=[propagate_btn, cancel_propagate_btn, undo_point_btn, clear_points_obj_btn, clear_all_points_obj_btn, clear_tracking_btn, clear_all_points_btn, video_input, matting_tab, export_tab])
+    dedupe_mattes_btn.click(lock_ui_dedupe, outputs=[propagate_btn, cancel_propagate_btn, undo_point_btn, clear_points_obj_btn, clear_all_points_obj_btn, clear_tracking_btn, clear_all_points_btn, dedupe_mattes_btn, video_input, matting_tab, export_tab]).then(replace_similar_matte_frames).then(unlock_ui, outputs=[propagate_btn, cancel_propagate_btn, undo_point_btn, clear_points_obj_btn, clear_all_points_obj_btn, clear_tracking_btn, clear_all_points_btn, dedupe_mattes_btn, video_input, matting_tab, export_tab]).then(update_image, inputs=frame_slider, outputs=image_viewer)
+    propagate_btn.click(lock_ui, outputs=[propagate_btn, cancel_propagate_btn, undo_point_btn, clear_points_obj_btn, clear_all_points_obj_btn, clear_tracking_btn, clear_all_points_btn, dedupe_mattes_btn, video_input, matting_tab, export_tab]).then(propagate_masks, outputs=[frame_slider, image_viewer]).then(unlock_ui, outputs=[propagate_btn, cancel_propagate_btn, undo_point_btn, clear_points_obj_btn, clear_all_points_obj_btn, clear_tracking_btn, clear_all_points_btn, dedupe_mattes_btn, video_input, matting_tab, export_tab])
     cancel_propagate_btn.click(cancel_propagation)
     point_viewer.select(change_slider, outputs=[frame_slider, object_id, color_picker], show_progress='hidden')
     export_type.input(change_export_settings, inputs=[export_type, export_content])

--- a/utils/duplicate_frame_handler.py
+++ b/utils/duplicate_frame_handler.py
@@ -7,9 +7,6 @@ from .progress_bar import progress_bar
 
 min_similarity_threshold = 0.8 # The compared matte (alpha) frames need to be at least this similar compared to the base matte alpha frame
 max_similarity_threshold = 0.98 # The compared matte (alpha) frame is similar to the point where it doesn't have to be processed / replaced
-temp_dir = "../temp/"
-frames_dir = os.path.join(temp_dir, "frames")
-mask_dir = os.path.join(temp_dir, "masks")
 
 # Use ORB comparison from opencv to compare two input frames/images for similarity
 def orb_comparison(img1, img2):
@@ -44,7 +41,7 @@ def generate_matted_frame(frame_path, mask_dir, frame_number):
     return result_frame
 
 # Replace the masks on disc with a specific "similar frames" list
-def replace_matte_frames(mask_dir, similar_frames):
+def replace_files_similar_mattes(mask_dir, similar_frames):
     last_mask_dir = os.path.join(mask_dir, similar_frames[-1])
     file_list = os.listdir(last_mask_dir)
     for i, frame in enumerate(similar_frames):
@@ -112,7 +109,7 @@ def replace_similar_matte_frames():
                 # If the frames are not similar, break out of the inner loop
                 break
         
-        replace_matte_frames(mask_dir, similar_frames)
+        replace_files_similar_mattes(mask_dir, similar_frames)
         
         # Find the actual index of the last similar frame in the input list and update the frame_index from that point onwards
         last_similar_frame_index = frame_numbers.index(similar_frames[-1])

--- a/utils/duplicate_frame_handler.py
+++ b/utils/duplicate_frame_handler.py
@@ -1,0 +1,132 @@
+import cv2
+import numpy as np
+import os
+import shutil
+import gradio as gr
+from .progress_bar import progress_bar
+
+min_similarity_threshold = 0.8 # The compared matte (alpha) frames need to be at least this similar compared to the base matte alpha frame
+max_similarity_threshold = 0.98 # The compared matte (alpha) frame is similar to the point where it doesn't have to be processed / replaced
+temp_dir = "../temp/"
+frames_dir = os.path.join(temp_dir, "frames")
+mask_dir = os.path.join(temp_dir, "masks")
+
+# Use ORB comparison from opencv to compare two input frames/images for similarity
+def orb_comparison(img1, img2):
+    orb = cv2.ORB_create()
+    kp1, des1 = orb.detectAndCompute(img1, None)
+    kp2, des2 = orb.detectAndCompute(img2, None)
+
+    bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+
+    matches = bf.match(des1, des2)
+    similarity_score = len(matches) / max(len(kp1), len(kp2))
+    return similarity_score
+
+# To compare without other elements or the background on the frame affecting the comparison, the mask luma matte gets applied to the frame
+def generate_matted_frame(frame_path, mask_dir, frame_number):
+    frame = cv2.imread(frame_path)
+    frame_mask_dir = os.path.join(mask_dir, frame_number)
+    if not os.path.exists(frame_mask_dir):
+        # Warning could not find masks
+        return None
+    
+    # Create empty mask image
+    mask_image = np.zeros((frame.shape[0], frame.shape[1]), dtype=np.uint8)
+    # Combine all masks from mask folder into one mask image for comparison
+    for matte in os.listdir(frame_mask_dir):
+        matte_path = os.path.join(frame_mask_dir, matte)
+        matte_image = cv2.imread(matte_path, cv2.IMREAD_GRAYSCALE)
+        mask_image = cv2.bitwise_or(mask_image, matte_image)
+        
+    # Use the combined mask image as the overall mask luma matte
+    result_frame = cv2.bitwise_and(frame, frame, mask=mask_image)
+    return result_frame
+
+# Replace the masks on disc with a specific "similar frames" list
+def replace_matte_frames(mask_dir, similar_frames):
+    last_mask_dir = os.path.join(mask_dir, similar_frames[-1])
+    file_list = os.listdir(last_mask_dir)
+    for i, frame in enumerate(similar_frames):
+        if i == len(similar_frames) - 1:  # Skip the last sourcing frame
+            break
+        for file in file_list:
+            file_path = os.path.join(last_mask_dir, file)
+            replace_mask_dir = os.path.join(mask_dir, frame, file)
+            shutil.copy(file_path, replace_mask_dir)
+
+# Main function to replace similar (matted) frames with one single matte frame
+def replace_similar_matte_frames():
+    # Resolve absolute path of file back to project root folder
+    utils_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.abspath(os.path.join(utils_dir, ".."))
+    
+    frames_dir = os.path.join(project_root, "temp", "frames")
+    mask_dir = os.path.join(project_root, "temp", "masks")
+
+    frame_numbers = []
+
+    # Check if the frames directory exists
+    if not os.path.exists(frames_dir):
+        gr.Warning("Could not find frames to dedupe.\nPlease upload a video first.", duration=5)
+        return
+    # Get the list of propagated frame numbers
+    for filename in os.listdir(frames_dir):
+        if filename.endswith(".png"):
+            frame_numbers.append(os.path.splitext(filename)[0])
+            
+    # Check if the masks directory has the same amount of masks as the amount of frames in the video file
+    num_of_masks = len(os.listdir(mask_dir))
+    frames_amount = len(frame_numbers)
+    if num_of_masks != frames_amount:
+        gr.Warning("Mismatch between frames and masks.\nPlease fully track objects first.", duration=10)
+        return
+
+    frame_index = 0 # Keeps track of the current "base" frame for comparisons
+    deduped_frames_amount = 0 # Keep track of how many frames/masks have been replaced/deduped
+
+    # Initialize the base frame
+    start_base_frame_path = os.path.join(frames_dir, frame_numbers[frame_index] + ".png")
+    base_frame = generate_matted_frame(start_base_frame_path, mask_dir, frame_numbers[frame_index]) # Frame used for ORB comparison
+
+    gr.Info("Deduping matte frames...", duration=3)
+    print("Deduping matte frames...")
+
+    while True:
+        progress = frame_index / frames_amount
+        progress_bar(progress)
+        similar_frames = []
+        similar_frames.append(frame_numbers[frame_index])
+
+        for next_index in range(frame_index + 1, len(frame_numbers)):
+            # Load the next frame
+            next_frame_path = os.path.join(frames_dir, frame_numbers[next_index] + ".png")
+            next_frame = generate_matted_frame(next_frame_path, mask_dir, frame_numbers[next_index])
+            
+            # Compare the current frame with the next frame
+            similarity_score = orb_comparison(base_frame, next_frame)
+            if similarity_score > min_similarity_threshold and similarity_score < max_similarity_threshold:
+                # If the frames are similar enough, add the next checked frame to the similar_frames list
+                similar_frames.append(frame_numbers[next_index])
+            else:
+                # If the frames are not similar, break out of the inner loop
+                break
+        
+        replace_matte_frames(mask_dir, similar_frames)
+        
+        # Find the actual index of the last similar frame in the input list and update the frame_index from that point onwards
+        last_similar_frame_index = frame_numbers.index(similar_frames[-1])
+        frame_index = last_similar_frame_index + 1
+
+        # Check if all the frames have been processed
+        if frame_index >= frames_amount:
+            progress_bar(1)
+            print(f"\nDeduped {deduped_frames_amount} matte frames")
+            gr.Info(f"Deduped {deduped_frames_amount} matte frames", duration=5)
+            return
+        else:
+            deduped_frames_amount += (len(similar_frames)-1) # Base frame gets stored in the list as well, hence the subtraction
+
+            # Load the next frame
+            new_base_frame_path = os.path.join(frames_dir, frame_numbers[frame_index] + ".png")
+            base_frame = generate_matted_frame(new_base_frame_path, mask_dir, frame_numbers[frame_index])

--- a/utils/progress_bar.py
+++ b/utils/progress_bar.py
@@ -1,0 +1,8 @@
+import sys
+
+# Flush progress to the command line, progress value should be between 0 to 1
+def progress_bar(progress, bar_length=60):
+    block = int(round(bar_length * progress))
+    text = "\r|{0}| {1:.0f}%".format("█" * block + " " * (bar_length - block), progress * 100)
+    sys.stdout.write(text)
+    sys.stdout.flush()


### PR DESCRIPTION
### Goal
While using Sammie-Roto for my projects (useful tool) I noticed that propagating the matte over footage which has duplicate frames, results in a "boiling" effect around the edges and sometimes even errors. I used to fix this manually in my editing software but with this added functionality in Sammie-Roto I hope to automatically fix the problem. This is specifically aimed for projects using anime or cartoon footage which tend to have multiple duplicate frames between new drawings.

### Implementation
New functions have been added to a separate file in a new utilities folder, which use OpenCV's ORB comparison method to compare two images/frames, returning a similarity score. Depending on the similarity between subsequent matted frames, mask files get replaced with one mask frame as a source or not. During the ORB comparison the generated luma matte mask of the specific frame gets used. This is done to prevent a moving background or other visual elements in a scene to have an effect on the similarity score.

Inside the replace_similar_matte_frames function instead of storing all the frame image data, simply the frame numbers and paths to specific frames/masks get stored and accessed.
A base frame gets selected to compare with and during subsequent while loop iterations the next frames get compared, during which similar frame numbers get stored in the similar_frames list. During iterations only two image files get accessed and compared (low memory impact). This process is repeated until a frame does not meet the threshold values and at that point the last similar frame gets used as the source file to replace the other similar mask files. The similar_frames list gets emptied, the base_frame index gets updated to the next unique frame and the while loop continues until all the frames have been processed.

Inside the while loop a progress bar function gets called with a calculation of frame index/total frames as input argument, which gets flushed to the terminal in a somewhat similar style as the propagate progress bar.
![Screenshot 2025-07-24 195023](https://github.com/user-attachments/assets/26515a10-cc10-42bd-92d1-62106a45b880)

The functionality has been implemented as a button in the segmentation tab, in which I've tried to conform to the functionality of the other buttons (lock_ui and unlock_ui variants were added to lock the track objects button and to not have the cancel button appear). Executing the functionality in the segmentation tab and refreshing the preview makes the user able to spot if any errors have occurred, before moving on to the matting or export tab. There are also checks inside the function to see if a temp frames folder exists (it doesn't seem to get created when first cloning and starting the program) and if there are the same amount of masks as frames before executing the rest of the function. In both cases it returns out of the function and gives a Gradio warning if it's not the case (to prevent undefined behavior).
![DedupeButton](https://github.com/user-attachments/assets/a59f3e5f-ebcf-4435-a19c-d86070933202)

### Results
Here is a comparison between a fully mask propagated clip, first without applying the dedupe matte function and after applying it.
![DedupeComparison](https://github.com/user-attachments/assets/4c2a88d9-a5d7-4a94-ac3d-8f9d1837941e)
![DedupeComparisonZoomedIn](https://github.com/user-attachments/assets/70729be0-9769-4ccc-a9a9-c5ee0705a16f)
The function was able to almost fully stabilize the moving edge of the masked character when standing still and it also removed 2 frames where the edge of the character completely changed without the character moving.