### PR TITLE
Automatic filename functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -217,7 +217,7 @@ def save_settings():
 # Load session from json file (create if missing)
 def load_session():
     default_session = {
-        "input_file_name": os.path.join(temp_dir, "output"),
+        "input_file_name": "output",
         "name_roto": True,
         "name_type": False,
         "name_content" : False,


### PR DESCRIPTION
### Goal
Due to a quality of life suggestion in the issues section of Sammie-Roto: https://github.com/Zarxrax/Sammie-Roto/issues/13
I looked into adding automatic filename functionality for version tracking purposes.

### Implementation
First of all when importing a video file, the file name (without file type extension) gets extracted and stored.
A new section in the export tab has been added for file naming options. By the clicking the checkboxes the user is able to represent the settings from Sammie in the filename, as well as a SammieRoto suffix and the date + time. These settings are stored in a new session.json file and is persistent throughout sessions. When updating the settings in the export tab a preview file name box gets automatically updated. Exporting the file still results in the user having to specify a folder with the download button (see limitation) but now with data automatically stored in the filename.

https://github.com/user-attachments/assets/34522dd9-36ec-4df3-8d2c-17a81aa4bfd2

### Limitation
I also looked into automatically storing the exported file at the path of the input file. However due to Gradio being a web interface this is not possible due to security considerations from the web browser.
<img width="752" height="58" alt="image" src="https://github.com/user-attachments/assets/ab0ba2ce-8493-413f-9a1e-70e985b85749" />
