### PR TITLE
Bugfix export object ID error (empty variable)

### DIFF
--- a/app.py
+++ b/app.py
@@ -990,7 +990,7 @@ def export_image(type, content, object):
             mask = fill_small_holes(mask)
             mask = remove_small_dots(mask)
             mask = grow_shrink(mask)
-            mask = border_fix(current_mask)
+            mask = border_fix(mask)
         elif content == "Matting":
             mask = gamma(mask)
             mask = grow_shrink_matte(mask)
@@ -1131,7 +1131,7 @@ def export_video(fps, type, content, object, progress=gr.Progress()):
                 mask = fill_small_holes(mask)
                 mask = remove_small_dots(mask)
                 mask = grow_shrink(mask)
-                mask = border_fix(current_mask)
+                mask = border_fix(mask)
             elif content == "Matting":
                 mask = gamma(mask)
                 mask = grow_shrink_matte(mask)


### PR DESCRIPTION
With the new addition of the border fix function a bug got introduced which prevents users from exporting a specific matte (Object ID).

<img width="1321" height="422" alt="image" src="https://github.com/user-attachments/assets/bb6f91f2-83b1-4bb0-98e7-80ad7d1b77b1" />

In the code, a current_mask variable gets called which is empty inside the specific scope of the function.